### PR TITLE
Fix Foundry launch args to use configured host and port

### DIFF
--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -26,7 +26,7 @@ impl AppConfig {
         let target_dir = get_target_directory();
 
         let foundry_host =
-            env::var("APPLICATION_HOST").unwrap_or_else(|_| "foundry.vtt".to_string());
+            env::var("APPLICATION_HOST").unwrap_or("foundry.vtt".to_string());
 
         let foundry_args = vec![
             format!("--dataPath={}", *paths::DATA_DIR),

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -25,10 +25,13 @@ impl AppConfig {
 
         let target_dir = get_target_directory();
 
+        let foundry_host =
+            env::var("APPLICATION_HOST").unwrap_or_else(|_| "foundry.vtt".to_string());
+
         let foundry_args = vec![
             format!("--dataPath={}", *paths::DATA_DIR),
-            "--port=4444".to_string(),
-            "--hostname=foundry.vtt".to_string(),
+            format!("--port={}", server_port),
+            format!("--hostname={}", foundry_host),
             "--noupnp".to_string(),
             "--proxySSL".to_string(),
         ];


### PR DESCRIPTION
## Summary
- ensure Foundry launches with the configured port and hostname

## Testing
- `make lint` *(fails: 'cargo-fmt' is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f3a505d88832180cb028e31ed841a